### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/web/deploy.html
+++ b/web/deploy.html
@@ -77,6 +77,15 @@
     </div>
 
     <script>
+        // Escape text for safe HTML insertion
+        function escapeHtml(str) {
+            return String(str)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#39;');
+        }
         let account = null;
         let provider = null;
         let signer = null;
@@ -208,13 +217,15 @@
 
         function showResults(result) {
             document.getElementById('results').style.display = 'block';
+            const ownerAddress = escapeHtml(document.getElementById('ownerAddress').value);
+            const treasuryAddress = escapeHtml(document.getElementById('treasuryAddress').value);
             document.getElementById('contractInfo').innerHTML = `
                 <div class="space-y-2">
                     <p><strong>Contract Address:</strong> ${result.address}</p>
                     <p><strong>Transaction Hash:</strong> <a href="${NETWORKS.baseSepolia.blockExplorerUrls[0]}/tx/${result.txHash}" target="_blank" class="underline">${result.txHash.slice(0, 10)}...${result.txHash.slice(-10)}</a></p>
                     <p><strong>Network:</strong> Base Sepolia</p>
-                    <p><strong>Owner:</strong> ${document.getElementById('ownerAddress').value}</p>
-                    <p><strong>Treasury:</strong> ${document.getElementById('treasuryAddress').value}</p>
+                    <p><strong>Owner:</strong> ${ownerAddress}</p>
+                    <p><strong>Treasury:</strong> ${treasuryAddress}</p>
                     <a href="${NETWORKS.baseSepolia.blockExplorerUrls[0]}/address/${result.address}" 
                        target="_blank" 
                        class="inline-block bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded-lg mt-4 transition-colors">


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/The_Truth/security/code-scanning/1](https://github.com/CreoDAMO/The_Truth/security/code-scanning/1)

To fix this issue, we should ensure that any potentially untrusted data interpolated into an HTML string via `innerHTML` is escaped such that any meta-characters (like `<`, `>`, `&`, `"`, `'`) are rendered harmless and not reinterpreted as HTML or script. The standard solution is to use a contextual encoder/escaper for HTML.

Specifically, before interpolating values from `ownerAddress` and `treasuryAddress`, escape them using a simple function that replaces HTML special characters with their safe entity equivalents (e.g., `<` → `&lt;`). This can be implemented within web/deploy.html in the relevant `<script>` block.

You should define a helper function (e.g. `escapeHtml`) in the script, and wrap all interpolations that can contain untrusted data with this function before inserting into `innerHTML`.  
- Edit the `showResults(result)` function:  
  - Replace direct usage of `document.getElementById('ownerAddress').value` and `document.getElementById('treasuryAddress').value` with their escaped versions.
- Add the escaping function near the top of the script.
- No new library is needed; a custom escaping helper suffices and is standard in frontend contexts.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
