### PR TITLE
Potential fix for code scanning alert no. 2: Missing rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "express": "^4.18.2",
-    "stripe": "^14.11.0"
+    "stripe": "^14.11.0",
+    "express-rate-limit": "^8.0.1"
   }
 }

--- a/web/server.js
+++ b/web/server.js
@@ -1,7 +1,17 @@
 const express = require('express');
 const path = require('path');
+const RateLimit = require('express-rate-limit');
 const app = express();
 const port = process.env.PORT || 5000;
+
+// Set up rate limiter: maximum of 100 requests per 15 minutes per IP
+const limiter = RateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs
+});
+
+// Apply rate limiter to all requests
+app.use(limiter);
 
 // Serve static files from the root directory
 // This will serve index.html, deploy.html, shop.html, app.js, etc.


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/The_Truth/security/code-scanning/2](https://github.com/CreoDAMO/The_Truth/security/code-scanning/2)

To fix the missing rate limiting, we should add a rate limiting middleware to the Express application. The simplest and most robust way is to use the popular `express-rate-limit` package, as recommended in the background material. We'll:

- Add `express-rate-limit` as a dependency.
- Import it in `web/server.js`.
- Configure a rate limiter (e.g., 100 requests per 15 minutes per IP, as per convention).
- Apply the limiter to all routes (`app.use(limiter)`) before any handlers, to protect not only the catch-all file server but also API endpoints and static file serving.

The only changes required are at the top of `web/server.js` to import and configure the rate limiter, and to add the middleware. No changes to logic or routes are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
