### PR TITLE
feat: Add GitHub Actions workflow for GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,49 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Compile browser artifacts
+        run: npm run compile-browser
+
+      - name: Build static site
+        run: ./build-static.sh
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v2
+        with:
+          path: ./dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "start": "node web/server.js",
     "dev": "node web/server.js",
     "build": "npm run compile && npm run generate-metadata",
+    "build:static": "./build-static.sh",
     "update-contract": "node deployment/update-contract.js",
     "deploy:vercel": "./deployment/deploy-everywhere.sh vercel",
     "deploy:railway": "./deployment/deploy-everywhere.sh railway",


### PR DESCRIPTION
This commit introduces a new GitHub Actions workflow to automatically build and deploy the application to GitHub Pages.

The workflow is triggered on pushes to the main branch and consists of two jobs: build and deploy.

The build job checks out the code, installs dependencies, builds the static site using the 'build-static.sh' script, and uploads the resulting 'dist' directory as a Pages artifact.

The deploy job then deploys the artifact to GitHub Pages.

Additionally, a 'build:static' script has been added to 'package.json' for convenience, and 'build-static.sh' has been made executable.