### PR TITLE
fix: Update deprecated actions in GitHub Pages workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,10 +16,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: '16'
 
@@ -33,7 +33,7 @@ jobs:
         run: ./build-static.sh
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist
 
@@ -46,4 +46,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
This commit updates the GitHub Actions workflow for deploying to GitHub Pages to use the latest versions of the actions. The previous versions were deprecated and caused the workflow to fail.

The following actions have been updated:
- `actions/checkout` from `v3` to `v4`
- `actions/setup-node` from `v3` to `v4`
- `actions/upload-pages-artifact` from `v2` to `v3`
- `actions/deploy-pages` from `v2` to `v4`