### PR TITLE
fix: Add missing dependency and update Node.js version in workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '16'
+          node-version: '18'
 
       - name: Install dependencies
         run: npm install

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "deploy:all": "echo 'Choose specific platform with deploy:[platform]'"
   },
   "devDependencies": {
+    "@nomicfoundation/hardhat-toolbox": "^3.0.0",
     "@nomiclabs/hardhat-ethers": "^2.2.3",
     "@nomiclabs/hardhat-etherscan": "^3.1.7",
     "@openzeppelin/contracts": "^4.9.3",


### PR DESCRIPTION
This commit fixes the GitHub Actions workflow by:
1.  Adding the missing `@nomicfoundation/hardhat-toolbox` dependency to `package.json`.
2.  Updating the Node.js version from 16 to 18, which is a supported LTS version for Hardhat.