### PR TITLE
Potential fix for code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/web/deployment-dashboard.html
+++ b/web/deployment-dashboard.html
@@ -500,7 +500,7 @@
                 
                 const logEntry = document.createElement('div');
                 logEntry.className = colors[level] || 'text-white';
-                logEntry.innerHTML = `[${timestamp}] [${type}] ${message}`;
+                logEntry.textContent = `[${timestamp}] [${type}] ${message}`;
                 
                 logs.appendChild(logEntry);
                 logs.scrollTop = logs.scrollHeight;


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/The_Truth/security/code-scanning/3](https://github.com/CreoDAMO/The_Truth/security/code-scanning/3)

The vulnerability arises from directly injecting potentially tainted text using `innerHTML` in the `addLog` method (line 503), allowing for malicious HTML/script injection into the DOM. To fix this, you should never use `innerHTML` with untrusted text. Instead, use `textContent` to set log messages, which will escape HTML meta-characters and render all input as plain text. 

However, since the log format adds structured decorations (timestamp and type), if you want to keep those as e.g. colored prefixes or styled HTML, you can construct those parts as HTML but *always* attach untrusted segments using `textContent` (not `innerHTML`) or first escape them. Here, the simplest and safest is to build up the log entry using DOM text nodes or assign everything via `textContent`.

**Concretely:**  
In web/deployment-dashboard.html, update the `addLog` method (lines 491–507). Replace constructing a div, setting its class, and setting its `innerHTML` to an interpolated string, with instead constructing a div, setting its class, and *setting* its textContent to the log string. This avoids reinterpreting DOM text as HTML.

No additional dependencies are needed, and this fix only affects the `addLog` method.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
