### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/web/server.js
+++ b/web/server.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const path = require('path');
+const fs = require('fs');
 const RateLimit = require('express-rate-limit');
 const cors = require('cors');
 
@@ -39,8 +40,15 @@ app.use('/LAW', express.static(path.join(__dirname, '..', 'LAW')));
 // Serve markdown files with correct MIME type
 app.get('/LAW/*.md', (req, res) => {
     const fileName = req.params[0];
+    const lawDir = path.resolve(__dirname, '..', 'LAW');
+    // Construct full file path and normalize
+    const filePath = path.resolve(lawDir, fileName + '.md');
+    // Ensure the resolved path is within the LAW directory
+    if (!filePath.startsWith(lawDir + path.sep)) {
+        return res.status(403).send('Access denied');
+    }
     res.setHeader('Content-Type', 'text/markdown');
-    res.sendFile(path.join(__dirname, '..', 'LAW', fileName + '.md'));
+    res.sendFile(filePath);
 });
 
 // Serve PWA manifest with correct MIME type


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/The_Truth/security/code-scanning/4](https://github.com/CreoDAMO/The_Truth/security/code-scanning/4)

The best fix is to ensure that the resolved path (the markdown file being served) always remains within the intended `LAW` directory. This involves the following steps:

- Safely join and resolve the root directory (the `LAW` directory) and the user-supplied filename, using `path.resolve`.
- Normalize and resolve the resulting path with `path.resolve` and optionally `fs.realpathSync` to avoid bypasses using symlinks or special segments like `".."`.
- Compare the resulting absolute path to ensure it starts with the absolute path of the intended root (the `LAW` directory). Deny the request if it does not.
- Optionally, restrict the file name to not contain path separators (e.g., allow only simple file names), or further sanitize with a package like `sanitize-filename` if appropriate.
- Return HTTP 403 or 400 if the validation fails; otherwise, proceed with serving the file.

This fix applies only to the handler on line 40–44 in `web/server.js`:
- Update these lines to perform the above safety checks, and only call `res.sendFile` if the checks pass.

We will need to import the `fs` module at the top if it is not already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
