### PR TITLE
Potential fix for code scanning alert no. 5: Exposure of private files

### DIFF
--- a/dist/server.js
+++ b/dist/server.js
@@ -29,8 +29,8 @@ app.use(cors({
 }));
 app.use(express.json());
 
-// Serve static files from the web directory first (highest priority)
-app.use(express.static(__dirname));
+// Serve static files from explicit subdirectories (e.g., assets)
+app.use('/assets', express.static(path.join(__dirname, 'assets')));
 // Then serve from parent directory
 app.use(express.static(path.join(__dirname, '..')));
 


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/The_Truth/security/code-scanning/5](https://github.com/CreoDAMO/The_Truth/security/code-scanning/5)

To properly fix this issue, restrict which files and folders under `dist` are served statically. Instead of serving the entire `dist` directory, only serve specifically intended public asset subfolders (such as `dist/assets`, `dist/public`, `dist/static`), or only specific file types (such as `.js`, `.css`, `.png`). This is typically done by configuring explicit routes with `express.static` for known-safe subdirectories, or by serving files individually via whitelisted routes.

In dist/server.js, remove or replace the line:
```js
app.use(express.static(__dirname));
```
with more restrictive static serving. For example, if public assets are in `dist/assets` (adjust to actual usage), use:
```js
app.use('/assets', express.static(path.join(__dirname, 'assets')));
```
If additional static directories or file types need whitelisting, explicitly add those as well, one per call.

If there are public files directly under `dist` (e.g., `index.html`, images), serve them via individual routes or copy them to a dedicated public folder. Do not serve all of `dist` with a blanket static call.

No new external libraries are required; only changes to lines serving static files.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
