### PR TITLE
Potential fix for code scanning alert no. 9: DOM text reinterpreted as HTML

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -1797,14 +1797,19 @@
                             <div class="w-64 h-64 bg-gradient-to-br from-purple-500 to-pink-500 rounded-lg mx-auto mb-4 flex items-center justify-center text-white font-bold text-xl">
                                 AI Design Preview
                             </div>
-                            <h4 class="text-lg font-semibold mb-2">${result.design.philosophicalTheme} ${result.design.merchantType}</h4>
-                            <p class="text-gray-400 mb-4">Generated from The Truth #${nftId}</p>
-                            <div class="text-2xl font-bold text-green-400 mb-4">$${result.pricing.total}</div>
+                            <h4 class="text-lg font-semibold mb-2"><span id="design-theme-merchant"></span></h4>
+                            <p class="text-gray-400 mb-4">Generated from The Truth #<span id="design-nft-id"></span></p>
+                            <div class="text-2xl font-bold text-green-400 mb-4" id="design-pricing-total"></div>
                             <button class="bg-green-600 hover:bg-green-700 px-6 py-3 rounded-lg font-semibold">
                                 🛒 Order Now
                             </button>
                         </div>
                     `;
+                    // Safely inject user data as text, not HTML
+                    document.getElementById('design-theme-merchant').textContent = result.design.philosophicalTheme + ' ' + result.design.merchantType;
+                    document.getElementById('design-nft-id').textContent = nftId;
+                    document.getElementById('design-pricing-total').textContent = '$' + result.pricing.total;
+
                     showSuccess('AI merch design generated successfully!');
                 } else {
                     showError('Failed to generate merch design');


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/The_Truth/security/code-scanning/9](https://github.com/CreoDAMO/The_Truth/security/code-scanning/9)

**General Fix:**  
To guard against cross-site scripting, *never* insert untrusted user input into the DOM using `.innerHTML` unless you have sanitized and/or escaped it appropriately. Instead, when building DOM content with dynamic values, use text node assignment (`.textContent`, `.innerText`, or DOM manipulation/creation methods) for any untrusted data.

**Best Fix for This Code:**  
- In this particular case, since the entire HTML for `design-preview` is being constructed via a template literal, but only part of the content is dynamic (the value of `${nftId}` and potentially other fields such as `${result.design.philosophicalTheme}` and `${result.design.merchantType}`), the fix is:
  - Set `.innerHTML` to a template that contains only *static* content or trusted markup.
  - For user-controlled dynamic content (like `nftId`), inject it only via `.textContent` into the relevant element(s), after the initial HTML is rendered.
- This requires:
  1. Modifying the markup so that the dynamic values are provided via element IDs or data attributes as placeholders.
  2. Directly setting the text content (e.g., via `.textContent`) of each such element with the value of `nftId` etc.
- Only line 1795-1807 of `web/index.html` need to change (plus follow-up lines as needed to inject the dynamic data).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
