### PR TITLE
Potential fix for code scanning alert no. 18: Incomplete URL scheme check

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -58,7 +58,7 @@
                     // Remove all script tags and event handlers
                     let sanitized = html
                         .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
-                        .replace(/javascript:/gi, '')
+                        .replace(/javascript:|data:|vbscript:/gi, '')
                         .replace(/on\w+\s*=\s*["'][^"']*["']/gi, '')
                         .replace(/on\w+\s*=\s*[^>\s]+/gi, '');
 


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/The_Truth/security/code-scanning/18](https://github.com/CreoDAMO/The_Truth/security/code-scanning/18)

To fix the problem, we should update the fallback sanitizer so that, in addition to removing occurrences of `javascript:`, it also removes `data:` and `vbscript:` schemes—case-insensitively and globally. This ensures that malicious URLs using those schemes cannot slip through when the sanitizer fallback is invoked. The most focused fix is to add two lines after the line where `.replace(/javascript:/gi, '')` is used, adding `.replace(/data:/gi, '')` and `.replace(/vbscript:/gi, '')`. Or, more maintainably, combine all into a single regular expression: `.replace(/javascript:|data:|vbscript:/gi, '')`. 

This fix should be made inside the `initializeSecureFallback` function, specifically modifying the chain of `.replace()` calls that sanitize the HTML input. No additional imports or dependencies are needed for this edit.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
