### PR TITLE
Potential fix for code scanning alert no. 19: Bad HTML filtering regexp

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -57,7 +57,7 @@
 
                     // Remove all script tags and event handlers
                     let sanitized = html
-                        .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, '')
+                        .replace(/<script\b[^<]*(?:(?!<\/script\s*[^>]*>)[^<]*)*<\/script\s*[^>]*>/gi, '')
                         .replace(/javascript:|data:|vbscript:/gi, '')
                         .replace(/on\w+\s*=\s*["'][^"']*["']/gi, '')
                         .replace(/on\w+\s*=\s*[^>\s]+/gi, '');


### PR DESCRIPTION
Potential fix for [https://github.com/CreoDAMO/The_Truth/security/code-scanning/19](https://github.com/CreoDAMO/The_Truth/security/code-scanning/19)

To properly mitigate the problem, we should replace the faulty regular expression with either:

1. A more robust regular expression that also matches closing tags with spaces or extra attributes (e.g. `</script foo="bar">`, `</script >`) — handling some of the browser's tolerant parsing; AND
2. If possible, perform the removal in a way that is defensible given the fallback's constraints (ideally without regular expressions, or only for clearly single tags).

However, since we're limited by what’s already in the fallback, and we cannot pull in large libraries (as this is the secure fallback if all script/CDN loading fails), the best fix here is to update the regex on line 60 to match any script closing tag that starts with `</script`, followed by optional whitespace, possible attributes, and a closing `>`, in a case-insensitive way:

```js
/<script\b[^<]*(?:(?!<\/script\s*[^>]*>)[^<]*)*<\/script\s*[^>]*>/gi
```
This new regex replaces the previous closing tag match with `<\/script\s*[^>]*>`, handling cases like `</script foo="bar">`, `</script >`, etc., while maintaining the prior matching and avoiding catastrophic backtracking.

**Change needed:**  
- Only line 60 in web/index.html needs to be updated with the new regex.
- No new imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
